### PR TITLE
class-settings-importer: eliminate redundant HTTP request

### DIFF
--- a/includes/panel/classes/importers/class-settings-importer.php
+++ b/includes/panel/classes/importers/class-settings-importer.php
@@ -21,8 +21,7 @@ class OWP_Settings_Importer {
 		}
 
 		// Get file contents and decode
-		$raw  = file_get_contents( $file );
-		$data = @unserialize( $raw, [ 'allowed_classes' => false ]  );
+		$data = @unserialize( $data, [ 'allowed_classes' => false ]  );
 
 		// Delete import file
 		//unlink( $file );


### PR DESCRIPTION
The HTTP request was already performed by OWP_Demos_Helpers::get_remote(), and `$data` already contains the response body.

As a side effect, this avoids certificate verification problems because `file_get_contents()` does not use the WordPress CA bundle.